### PR TITLE
Minor Schedule Changes

### DIFF
--- a/config.json
+++ b/config.json
@@ -218,17 +218,17 @@
           "end": "14:30",
           "title": "Lunch",
           "icon": "food"
-        }
-      ]
-    },
-    {
-      "events": [
+        },
         {
           "start": "14:30",
           "end": "15:15",
           "title": "Workshop (TBC)",
           "icon": "flask"
-        },
+        }
+      ]
+    },
+    {
+      "events": [
         {
           "start": "15:30",
           "end": "16:15",

--- a/config.json
+++ b/config.json
@@ -193,7 +193,7 @@
         {
           "start": "09:30",
           "end": "11:00",
-          "title": "Registration opens",
+          "title": "Registration",
           "icon": "edit"
         },
         {

--- a/config.json
+++ b/config.json
@@ -238,6 +238,12 @@
         {
           "start": "16:30",
           "end": "17:15",
+          "title": "Capture the Flag",
+          "icon": "flask"
+        },
+        {
+          "start": "17:30",
+          "end": "18:15",
           "title": "Workshop (TBC)",
           "icon": "flask"
         },

--- a/src/templates/schedule.hbs
+++ b/src/templates/schedule.hbs
@@ -9,7 +9,7 @@
 		<div class="row set">
 			{{#each events}}
 				<div class="event">
-					<div class="time">{{start}}{{#if end}} - {{end}}{{/if}}</div>
+					<div class="time">{{start}}{{#if end}} &ndash; {{end}}{{/if}}</div>
 					<div class="line row center">
 						<div class="icon">
 							<img src="/assets/icons/{{icon}}.svg" />


### PR DESCRIPTION
- Add MLH Capture the Flag event
- Remove the `opens` from `Registration opens`
- Tweak the layout slightly so everything isn’t quite so squashed on the second row
- Use a `–` (n-dash) rather than a `-` (hyphen) in the times in the schedule