### PR TITLE
Feat/applications statistics 

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
     "check:fix": "biome check --write .",
     "dev": "tsx src/main.ts",
     "dev:watch": "tsx watch src/main.ts",
+    "generate": "prisma generate && prisma generate --sql",
     "test": "vitest run --silent",
     "type-check": "tsc --noEmit"
   },

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -5,7 +5,8 @@
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 
 generator client {
-    provider = "prisma-client-js"
+    provider        = "prisma-client-js"
+    previewFeatures = ["typedSql"]
 }
 
 datasource db {

--- a/server/prisma/sql/getApplicationsGroupedByDisciplineOfStudy.sql
+++ b/server/prisma/sql/getApplicationsGroupedByDisciplineOfStudy.sql
@@ -1,0 +1,10 @@
+SELECT
+    SUBSTRING(userFlag."flagName" from 21) as "disciplineOfStudy",
+    COUNT(userInfo.user_id) as "count"
+FROM "UserInfo" userInfo
+LEFT JOIN "UserFlag" userFlag on userInfo.user_id = userFlag.user_id
+WHERE true
+    AND application_status='submitted'
+    AND userFlag."flagName" like 'discipline-of-study:%'
+GROUP BY
+    userFlag."flagName"

--- a/server/src/config/staging.ts
+++ b/server/src/config/staging.ts
@@ -1,5 +1,5 @@
-import { ConfigIn } from "@/config/schema";
-import { DeepPartial } from "@/types/deep-partial";
+import type { ConfigIn } from "@/config/schema";
+import type { DeepPartial } from "@/types/deep-partial";
 
 export default {
   origin: "https://api.durhack-staging.com",

--- a/server/src/decorators/authorise.ts
+++ b/server/src/decorators/authorise.ts
@@ -67,6 +67,7 @@ export function onlyGroups(groups: Group[]) {
 
 export enum Group {
   admins = "/admins",
+  organisers = "/organisers",
   volunteers = "/volunteers",
   hackers = "/hackers",
 }

--- a/server/src/routes/application/application-handlers.ts
+++ b/server/src/routes/application/application-handlers.ts
@@ -307,7 +307,7 @@ class ApplicationHandlers {
       assert(user)
 
       const body = await json(request, response)
-      let payload = extraDetailsFormSchema.parse(body)
+      const payload = extraDetailsFormSchema.parse(body)
 
       const prismaUserInfoFields = {
         tShirtSize: payload.tShirtSize,

--- a/server/src/routes/applications/applications-handlers.ts
+++ b/server/src/routes/applications/applications-handlers.ts
@@ -1,0 +1,114 @@
+import { getApplicationsGroupedByDisciplineOfStudy } from "@prisma/client/sql"
+
+import { Group, onlyGroups } from "@/decorators/authorise"
+import type { Middleware } from "@/types"
+import { prisma } from "@/database"
+
+class ApplicationsHandlers {
+  /**
+   * Returns a middleware that handles a GET request by responding with a JSON payload containing summary statistics
+   * relating to DurHack applications.
+   */
+  @onlyGroups([Group.organisers, Group.admins])
+  getApplicationsSummary(): Middleware {
+    return async (request, response) => {
+      const result = await prisma.userInfo.count({
+        where: {
+          applicationStatus: {
+            equals: "submitted",
+          },
+        },
+      })
+
+      response.json({
+        data: {
+          total_application_count: result
+        }
+      })
+    }
+  }
+
+  /**
+   * Returns a middleware that handles a GET request by responding with a JSON payload containing a list of
+   * institutions and their application counts.
+   * Only institutions with applications are included; omission of an institution means it has zero applications.
+   */
+  @onlyGroups([Group.organisers, Group.admins])
+  getApplicationsByInstitution(): Middleware {
+    return async (request, response) => {
+      const result = await prisma.userInfo.groupBy({
+        by: ['university'],
+        where: {
+          applicationStatus: {
+            equals: "submitted",
+          },
+        },
+        _count: {
+          userId: true,
+        }
+      })
+
+      const rows = result.map((resultItem) => ({
+        institution: resultItem.university,
+        application_count: resultItem._count.userId,
+      }))
+
+      response.json({
+        data: rows
+      })
+    }
+  }
+
+  /**
+   * Returns a middleware that handles a GET request by responding with a JSON payload containing a list of
+   * levels of study and their application counts.
+   * Only levels of study with applications are included; omission of a level of study means it has zero applications.
+   */
+  @onlyGroups([Group.organisers, Group.admins])
+  getApplicationsByLevelOfStudy(): Middleware {
+    return async (request, response) => {
+      const result = await prisma.userInfo.groupBy({
+        by: ['levelOfStudy'],
+        where: {
+          applicationStatus: {
+            equals: "submitted",
+          },
+        },
+        _count: {
+          userId: true,
+        }
+      })
+
+      const rows = result.map((resultItem) => ({
+        level_of_study: resultItem.levelOfStudy,
+        application_count: resultItem._count.userId,
+      }))
+
+      response.json({
+        data: rows
+      })
+    }
+  }
+
+  /**
+   * Returns a middleware that handles a GET request by responding with a JSON payload containing a list of
+   * disciplines of study and their application counts.
+   * Only disciplines of study with applications are included; omission of a discipline of study means it has zero applications.
+   */
+  @onlyGroups([Group.organisers, Group.admins])
+  getApplicationsByDisciplineOfStudy(): Middleware {
+    return async (request, response) => {
+      const result = await prisma.$queryRawTyped(getApplicationsGroupedByDisciplineOfStudy())
+      const rows = result.map((resultItem) => ({
+        discipline_of_study: resultItem.disciplineOfStudy,
+        application_count: Number(resultItem.count)
+      }))
+      response.json({
+        data: rows
+      })
+    }
+  }
+}
+
+const applicationsHandlers = new ApplicationsHandlers()
+export { applicationsHandlers }

--- a/server/src/routes/applications/index.ts
+++ b/server/src/routes/applications/index.ts
@@ -1,0 +1,34 @@
+import { App } from "@otterhttp/app"
+
+import type { Request, Response } from "@/types"
+import { methodNotAllowed } from "@/middleware/method-not-allowed";
+import { authenticate } from "@/middleware/authenticate";
+import { forbiddenOrUnauthorised } from "@/middleware/forbidden-or-unauthorised";
+
+import { applicationsHandlers } from "./applications-handlers";
+
+export const applicationsApp = new App<Request, Response>()
+
+applicationsApp.route("/")
+  .all(methodNotAllowed(["GET"]))
+  .all(authenticate())
+  .get(applicationsHandlers.getApplicationsSummary())
+  .all(forbiddenOrUnauthorised())
+
+applicationsApp.route("/by-institution")
+  .all(methodNotAllowed(["GET"]))
+  .all(authenticate())
+  .get(applicationsHandlers.getApplicationsByInstitution())
+  .all(forbiddenOrUnauthorised())
+
+applicationsApp.route("/by-level-of-study")
+  .all(methodNotAllowed(["GET"]))
+  .all(authenticate())
+  .get(applicationsHandlers.getApplicationsByLevelOfStudy())
+  .all(forbiddenOrUnauthorised())
+
+applicationsApp.route("/by-discipline-of-study")
+  .all(methodNotAllowed(["GET"]))
+  .all(authenticate())
+  .get(applicationsHandlers.getApplicationsByDisciplineOfStudy())
+  .all(forbiddenOrUnauthorised())

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2,6 +2,7 @@ import { App } from "@otterhttp/app"
 
 import { methodNotAllowed } from "@/middleware/method-not-allowed"
 import { applicationApp } from "@/routes/application"
+import { applicationsApp } from "@/routes/applications"
 import { authApp } from "@/routes/auth"
 import { userApp } from "@/routes/user"
 import { profilesApp } from "@/routes/profiles"
@@ -19,4 +20,5 @@ routesApp
 routesApp.use("/auth", authApp)
 routesApp.use("/user", userApp)
 routesApp.use("/application", applicationApp)
+routesApp.use("/applications", applicationsApp)
 routesApp.use("/profiles/:userId", profilesApp)


### PR DESCRIPTION
add some API routes
- `/applications`
- `/applications/by-institution`
- `/applications/by-level-of-study`
- `/applications/by-discipline-of-study`

which provide useful summary statistics (counts 😛) of DurHack applications, optionally grouped by various attributes